### PR TITLE
filterURL (filter type of chat by link)

### DIFF
--- a/filterURL.php
+++ b/filterURL.php
@@ -84,20 +84,20 @@ $out3 = $result1['out3'] ?? null; // id message
 # GROUP / CHANNEL 
 # PRIVATE
 
-// .... your logic
+// .... your logic here
 }
 
 }elseif($out1 === 'b' || $out1 === 'B') {
 $out3 = $result1['out3'] ?? null; // id message
 # BOT
 
-// .... your logic
+// .... your logic here
 
 }elseif($out1 === 'u' || $out1 === 'U') {
 $out3 = $result1['out3'] ?? null; // id message
 # USER
 
-// .... your logic
+// .... your logic here
 
 }else{
 
@@ -110,7 +110,7 @@ $out2 = $result1['out2'] ?? null; // id message
 # GROUP / CHANNEL 
 # PUBLIC
 
-// .... your logic
+// .... your logic here
 
 }
 


### PR DESCRIPTION
Function to filter the chat type by telegram url with custom filters: (b/u) 

all type of chats: channel/group/user/bot || public/private

( From my project: @GetAnyMessageRobot )

# Written by PHPwiz ( php-wiz )

# explanation:
$out1 = $result1['out1'] ?? null; // PATH URL 1
$out2 = $result1['out2'] ?? null; // PATH URL 2
$out3 = $result1['out3'] ?? null;  // PATH URL 3
$out4 = $result1['out4'] ?? null; // PATH URL 4
$out5 = $result1['out5'] ?? null; // PATH URL 5

PATH URL 1 ($out1):
if path is c/C = private chat(group/channel)
if path is u/U = user chat
if path is b/B = chat bot
else = (username) so its public channel/group 

*checks if path does not start with + to filter out invitation links.
*Check only on Telegram links.